### PR TITLE
Add Read() functions to the Client interface

### DIFF
--- a/google/cloud/bigquery/client.cc
+++ b/google/cloud/bigquery/client.cc
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/bigquery/client.h"
+
 #include <memory>
 
-#include "google/cloud/bigquery/client.h"
 #include "google/cloud/bigquery/connection.h"
 #include "google/cloud/bigquery/connection_options.h"
 #include "google/cloud/bigquery/internal/connection_impl.h"
@@ -29,6 +30,19 @@ using ::google::cloud::StatusOr;
 StatusOr<std::string> Client::CreateSession(std::string parent_project_id,
                                             std::string table) {
   return conn_->CreateSession(parent_project_id, table);
+}
+
+ReadResult<Row> Client::Read(std::string parent_project_id, std::string table,
+                             std::vector<std::string> columns) {
+  return {};
+}
+
+ReadResult<Row> Client::Read(ReadStream<Row> const& read_stream) { return {}; }
+
+StatusOr<std::vector<ReadStream<Row>>> Client::ParallelRead(
+    std::string parent_project_id, std::string table,
+    std::vector<std::string> columns) {
+  return {};
 }
 
 std::shared_ptr<Connection> MakeConnection(ConnectionOptions const& options) {

--- a/google/cloud/bigquery/client.h
+++ b/google/cloud/bigquery/client.h
@@ -26,6 +26,101 @@ namespace google {
 namespace cloud {
 namespace bigquery {
 inline namespace BIGQUERY_CLIENT_NS {
+
+// TODO(aryann): Move all of the classes defined here except Client to their own
+// files.
+
+// TODO(aryann): Add an implementation for a row. We must support schemas that
+// are known at compile-time as well as those that are known at run-time.
+class Row {};
+
+template <typename RowType>
+class RowSet {
+ public:
+  using value_type = StatusOr<RowType>;
+  class iterator {
+   public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = RowSet::value_type;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
+    reference operator*() { return curr_; }
+    pointer operator->() { return &curr_; }
+
+    iterator& operator++() { return *this; }
+
+    iterator operator++(int) { return {}; }
+
+    friend bool operator==(iterator const& a, iterator const& b) { return {}; }
+
+    friend bool operator!=(iterator const& a, iterator const& b) {
+      return !(a == b);
+    }
+
+   private:
+    StatusOr<RowType> curr_;
+  };
+
+  iterator begin() { return {}; }
+
+  iterator end() { return {}; }
+};
+
+// Represents the result of a read operation.
+//
+// Note that at most one pass can be made over the data returned from a
+// `ReadResult`.
+template <typename RowType>
+class ReadResult {
+ public:
+  // Returns a `RowSet` which can be used to iterate through the rows that are
+  // presented by this object.
+  RowSet<RowType> Rows() { return {}; }
+
+  // Returns a zero-based index of the last row returned by the `Rows()`
+  // iterator. If no rows have been read yet, returns -1.
+  int CurrentOffset() { return {}; }
+
+  // Returns a value between 0 and 1, inclusive, that indicates the progress in
+  // the result set based on the number of rows the server has processed.
+  //
+  // Note that if this ReadResult was created through
+  // `bigquery::Client::ParallelRead()` or if a row filter was provided, then
+  // the returned value will not necessarily equal to the current offset divided
+  // by the number of rows in the `ReadResult`:
+  //
+  //   * In the case of a parallel read, data are assigned to
+  //     `bigquery::ReadStream`s lazily by the server. The server does not know
+  //     the total number of rows that will be assigned to the stream ahead of
+  //     time, so it uses a denominator that is guaranteed to never exceed the
+  //     maximum number of rows that are allowed to be assigned.
+  //
+  //   * In the presence of a row filter, the denominator is not known until all
+  //     rows are read because some rows may be excluded. As such, the server
+  //     uses an estimate for the number of pre-filtering rows.
+  //
+  double FractionConsumed() { return {}; }
+};
+
+template <typename RowType>
+class ReadStream {};
+
+// Serializes an instance of `ReadStream` for transmission to another process.
+template <typename RowType>
+StatusOr<std::string> SerializeReadStream(
+    ReadStream<RowType> const& read_stream) {
+  return {};
+}
+
+// Deserializes the provided string to a `ReadStream`, if able.
+template <typename RowType>
+StatusOr<ReadStream<RowType>> DeserializeReadStream(
+    std::string serialized_read_stream) {
+  return {};
+}
+
 class Client {
  public:
   explicit Client(std::shared_ptr<Connection> conn) : conn_(std::move(conn)) {}
@@ -48,8 +143,37 @@ class Client {
   //
   // This function is just a proof of concept to ensure we can send
   // requests to the server.
-  google::cloud::StatusOr<std::string> CreateSession(
-      std::string parent_project_id, std::string table);
+  StatusOr<std::string> CreateSession(std::string parent_project_id,
+                                      std::string table);
+
+  // Reads the given table.
+  //
+  // The read is performed on behalf of `parent_project_id`.
+  //
+  // `table` must be in the form `PROJECT_ID:DATASET_ID.TABLE_ID`.
+  //
+  // There are no row ordering guarantees.
+  ReadResult<Row> Read(std::string parent_project_id, std::string table,
+                       std::vector<std::string> columns = {});
+
+  // Performs a read using a `ReadStream` returned by
+  // `bigquery::Client::ParallelRead()`. See the documentation of
+  // `ParallelRead()` for more information.
+  ReadResult<Row> Read(ReadStream<Row> const& read_stream);
+
+  // Creates one or more `ReadStream`s that can be used to read data from a
+  // table in parallel.
+  //
+  // There are no row ordering guarantees. There are also no guarantees about
+  // which rows are assigned to which `ReadStream`s.
+  //
+  // Additionally, multiple calls to this function with the same inputs are not
+  // guaranteed to produce the same distribution or order of rows.
+  //
+  // After 24 hours, all `ReadStreams` created will stop working.
+  StatusOr<std::vector<ReadStream<Row>>> ParallelRead(
+      std::string parent_project_id, std::string table,
+      std::vector<std::string> columns = {});
 
  private:
   std::shared_ptr<Connection> conn_;

--- a/google/cloud/bigquery/connection_options.cc
+++ b/google/cloud/bigquery/connection_options.cc
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/bigquery/connection_options.h"
+
 #include <grpcpp/grpcpp.h>
+
 #include <memory>
 #include <string>
 
-#include "google/cloud/bigquery/connection_options.h"
 #include "google/cloud/bigquery/version.h"
 
 namespace google {

--- a/google/cloud/bigquery/connection_options.h
+++ b/google/cloud/bigquery/connection_options.h
@@ -16,6 +16,7 @@
 #define BIGQUERY_CONNECTION_OPTIONS_H_
 
 #include <grpcpp/grpcpp.h>
+
 #include <memory>
 #include <string>
 

--- a/google/cloud/bigquery/internal/bigquerystorage_stub.cc
+++ b/google/cloud/bigquery/internal/bigquerystorage_stub.cc
@@ -12,15 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/bigquery/internal/bigquerystorage_stub.h"
+
 #include <google/cloud/bigquery/storage/v1beta1/storage.grpc.pb.h>
 #include <google/cloud/bigquery/storage/v1beta1/storage.pb.h>
-#include <memory>
-
 #include <grpcpp/create_channel.h>
+
+#include <memory>
 
 #include "google/cloud/bigquery/connection.h"
 #include "google/cloud/bigquery/connection_options.h"
-#include "google/cloud/bigquery/internal/bigquerystorage_stub.h"
 #include "google/cloud/bigquery/internal/stream_reader.h"
 #include "google/cloud/bigquery/version.h"
 #include "google/cloud/grpc_utils/grpc_error_delegate.h"

--- a/google/cloud/bigquery/internal/bigquerystorage_stub.h
+++ b/google/cloud/bigquery/internal/bigquerystorage_stub.h
@@ -16,6 +16,7 @@
 #define BIGQUERY_INTERNAL_BIGQUERY_READ_STUB_H_
 
 #include <google/cloud/bigquery/storage/v1beta1/storage.pb.h>
+
 #include <memory>
 
 #include "google/cloud/bigquery/connection.h"

--- a/google/cloud/bigquery/internal/connection_impl.cc
+++ b/google/cloud/bigquery/internal/connection_impl.cc
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/bigquery/internal/connection_impl.h"
+
 #include <google/cloud/bigquery/storage/v1beta1/storage.pb.h>
+
 #include <memory>
 #include <sstream>
 #include <string>
 
 #include "google/cloud/bigquery/internal/bigquerystorage_stub.h"
-#include "google/cloud/bigquery/internal/connection_impl.h"
 #include "google/cloud/bigquery/version.h"
 #include "google/cloud/status_or.h"
 

--- a/google/cloud/bigquery/samples/read.cc
+++ b/google/cloud/bigquery/samples/read.cc
@@ -14,6 +14,64 @@
 
 #include "google/cloud/bigquery/client.h"
 
+namespace {
+
+using google::cloud::StatusOr;
+using google::cloud::bigquery::Client;
+using google::cloud::bigquery::ConnectionOptions;
+using google::cloud::bigquery::DeserializeReadStream;
+using google::cloud::bigquery::MakeConnection;
+using google::cloud::bigquery::ReadResult;
+using google::cloud::bigquery::ReadStream;
+using google::cloud::bigquery::Row;
+using google::cloud::bigquery::SerializeReadStream;
+
+// The following are some temporary examples of how I envision the Read()
+// functions will be used. Once we settle on the design and implementation,
+// we'll restructure these samples, so users can actually run them.
+
+void SimpleRead() {
+  ConnectionOptions options;
+  Client client(MakeConnection(options));
+  ReadResult<Row> result = client.Read(
+      "my-parent-project", "bigquery-public-data:samples.shakespeare",
+      /* columns = */ {"c1", "c2", "c3"});
+  for (StatusOr<Row> const& row : result.Rows()) {
+    if (row.ok()) {
+      // Do something with row.value();
+    }
+  }
+}
+
+void ParallelRead() {
+  // From coordinating job:
+  ConnectionOptions options;
+  Client client(MakeConnection(options));
+  StatusOr<std::vector<ReadStream<Row>>> read_session = client.ParallelRead(
+      "my-parent-project", "bigquery-public-data:samples.shakespeare",
+      /* columns = */ {"c1", "c2", "c3"});
+  if (!read_session.ok()) {
+    // Handle error;
+  }
+
+  for (ReadStream<Row> const& stream : read_session.value()) {
+    std::string bits = SerializeReadStream(stream).value();
+    // Send bits to worker job.
+  }
+
+  // From a worker job:
+  std::string bits;  // Sent by coordinating job.
+  ReadStream<Row> stream = DeserializeReadStream<Row>(bits).value();
+  ReadResult<Row> result = client.Read(stream);
+  for (StatusOr<Row> const& row : result.Rows()) {
+    if (row.ok()) {
+      // Do something with row.value();
+    }
+  }
+}
+
+}  // namespace
+
 int main(int argc, char* argv[]) {
   if (argc != 2) {
     std::cerr << "You must provide a project ID as a positional argument.\n";


### PR DESCRIPTION
Note that this builds on top of https://github.com/googleapis/google-cloud-cpp-bigquery/pull/4. See the note I left in that pull request about dependent changes.

My hope is to use this pull request to discuss the new Read() functions. No implementation is provided yet.

To see example usage, see samples/read.cc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-bigquery/8)
<!-- Reviewable:end -->
