### PR TITLE
Implement ParallelRead() and Read(ReadStream const&)

### DIFF
--- a/bazel/google_cloud_cpp_bigquery_deps.bzl
+++ b/bazel/google_cloud_cpp_bigquery_deps.bzl
@@ -83,6 +83,17 @@ def google_cloud_cpp_bigquery_deps():
             sha256 = "fd040f5238ff1e32b468d9d38e50f0d7f8da0828019948c9001e9a03093e1d8f",
         )
 
+    # Load rules_cc, used by googletest.
+    if "rules_cc" not in native.existing_rules():
+        http_archive(
+            name = "rules_cc",
+            strip_prefix = "rules_cc-a508235df92e71d537fcbae0c7c952ea6957a912",
+            urls = [
+                "https://github.com/bazelbuild/rules_cc/archive/a508235df92e71d537fcbae0c7c952ea6957a912.tar.gz",
+            ],
+            sha256 = "d21d38c4b8e81eed8fa95ede48dd69aba01a3b938be6ac03d2b9dc61886a7183",
+        )
+
     # We use the cc_proto_library() rule from @com_google_protobuf, which
     # assumes that grpc_cpp_plugin and grpc_lib are in the //external: module
     native.bind(

--- a/google/cloud/bigquery/BUILD
+++ b/google/cloud/bigquery/BUILD
@@ -57,8 +57,8 @@ cc_library(
   ],
   deps = [
       ":bigquery_client",
-      "@com_github_googleapis_google_cloud_cpp//google/cloud:google_cloud_cpp_common",
-      "@com_github_googleapis_google_cloud_cpp//google/cloud/testing_util:google_cloud_cpp_testing",
+      "@com_github_googleapis_google_cloud_cpp_common//google/cloud:google_cloud_cpp_common",
+      "@com_github_googleapis_google_cloud_cpp_common//google/cloud/grpc_utils:google_cloud_cpp_grpc_utils",
       "@com_google_googletest//:gtest",
   ],
 )
@@ -71,7 +71,7 @@ load(":bigquery_client_unit_tests.bzl", "bigquery_client_unit_tests")
     deps = [
         ":bigquery_client",
 	":bigquery_client_mocks",
-        "@com_github_googleapis_google_cloud_cpp//google/cloud:google_cloud_cpp_common",
-        "@com_github_googleapis_google_cloud_cpp//google/cloud/testing_util:google_cloud_cpp_testing",
-        "@com_google_googletest//:gtest",
+        "@com_github_googleapis_google_cloud_cpp_common//google/cloud:google_cloud_cpp_common",
+        "@com_github_googleapis_google_cloud_cpp_common//google/cloud/grpc_utils:google_cloud_cpp_grpc_utils",
+        "@com_google_googletest//:gtest_main",
     ]) for test in bigquery_client_unit_tests]

--- a/google/cloud/bigquery/BUILD
+++ b/google/cloud/bigquery/BUILD
@@ -31,6 +31,8 @@ cc_library(
     srcs = [
       "client.cc",
       "connection_options.cc",
+      "internal/streaming_read_result_source.cc",
+      "internal/streaming_read_result_source.h",
       "internal/stream_reader.h",
       "internal/bigquerystorage_stub.cc",
       "internal/bigquerystorage_stub.h",

--- a/google/cloud/bigquery/BUILD
+++ b/google/cloud/bigquery/BUILD
@@ -20,6 +20,10 @@ cc_library(
       "client.h",
       "connection.h",
       "connection_options.h",
+      "read_result.h",
+      "read_stream.h",
+      "row.h",
+      "row_set.h",
       "version.h",
       "version_info.h",
     ],
@@ -31,6 +35,7 @@ cc_library(
       "internal/bigquerystorage_stub.h",
       "internal/connection_impl.cc",
       "internal/connection_impl.h",
+      "read_stream.cc",
       "version.cc",
     ],
     deps = [

--- a/google/cloud/bigquery/BUILD
+++ b/google/cloud/bigquery/BUILD
@@ -17,50 +17,50 @@ package(default_visibility = ["//visibility:public"])
 # TODO(#17): Use CMake-generated lists of files for this rule.
 cc_library(
     name = "bigquery_client",
-    hdrs = [
-      "client.h",
-      "connection.h",
-      "connection_options.h",
-      "read_result.h",
-      "read_stream.h",
-      "row.h",
-      "row_set.h",
-      "version.h",
-      "version_info.h",
-    ],
     srcs = [
-      "client.cc",
-      "connection_options.cc",
-      "internal/streaming_read_result_source.cc",
-      "internal/streaming_read_result_source.h",
-      "internal/stream_reader.h",
-      "internal/bigquerystorage_stub.cc",
-      "internal/bigquerystorage_stub.h",
-      "internal/connection_impl.cc",
-      "internal/connection_impl.h",
-      "read_stream.cc",
-      "version.cc",
+        "client.cc",
+        "connection_options.cc",
+        "internal/bigquerystorage_stub.cc",
+        "internal/bigquerystorage_stub.h",
+        "internal/connection_impl.cc",
+        "internal/connection_impl.h",
+        "internal/stream_reader.h",
+        "internal/streaming_read_result_source.cc",
+        "internal/streaming_read_result_source.h",
+        "read_stream.cc",
+        "version.cc",
+    ],
+    hdrs = [
+        "client.h",
+        "connection.h",
+        "connection_options.h",
+        "read_result.h",
+        "read_stream.h",
+        "row.h",
+        "row_set.h",
+        "version.h",
+        "version_info.h",
     ],
     deps = [
         "@com_github_googleapis_google_cloud_cpp_common//google/cloud:google_cloud_cpp_common",
         "@com_github_googleapis_google_cloud_cpp_common//google/cloud/grpc_utils:google_cloud_cpp_grpc_utils",
-	"@com_google_googleapis//:bigquery_protos",
+        "@com_google_googleapis//:bigquery_protos",
     ],
 )
 
 # TODO(#17): Use CMake-generated lists of files for this rule.
 cc_library(
-  name = "bigquery_client_mocks",
-  srcs = [],
-  hdrs = [
-      "testing/mock_bigquerystorage_stub.h",
-  ],
-  deps = [
-      ":bigquery_client",
-      "@com_github_googleapis_google_cloud_cpp_common//google/cloud:google_cloud_cpp_common",
-      "@com_github_googleapis_google_cloud_cpp_common//google/cloud/grpc_utils:google_cloud_cpp_grpc_utils",
-      "@com_google_googletest//:gtest",
-  ],
+    name = "bigquery_client_mocks",
+    srcs = [],
+    hdrs = [
+        "testing/mock_bigquerystorage_stub.h",
+    ],
+    deps = [
+        ":bigquery_client",
+        "@com_github_googleapis_google_cloud_cpp_common//google/cloud:google_cloud_cpp_common",
+        "@com_github_googleapis_google_cloud_cpp_common//google/cloud/grpc_utils:google_cloud_cpp_grpc_utils",
+        "@com_google_googletest//:gtest",
+    ],
 )
 
 load(":bigquery_client_unit_tests.bzl", "bigquery_client_unit_tests")
@@ -70,8 +70,9 @@ load(":bigquery_client_unit_tests.bzl", "bigquery_client_unit_tests")
     srcs = [test],
     deps = [
         ":bigquery_client",
-	":bigquery_client_mocks",
+        ":bigquery_client_mocks",
         "@com_github_googleapis_google_cloud_cpp_common//google/cloud:google_cloud_cpp_common",
         "@com_github_googleapis_google_cloud_cpp_common//google/cloud/grpc_utils:google_cloud_cpp_grpc_utils",
         "@com_google_googletest//:gtest_main",
-    ]) for test in bigquery_client_unit_tests]
+    ],
+) for test in bigquery_client_unit_tests]

--- a/google/cloud/bigquery/BUILD
+++ b/google/cloud/bigquery/BUILD
@@ -14,6 +14,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
+# TODO(#17): Use CMake-generated lists of files for this rule.
 cc_library(
     name = "bigquery_client",
     hdrs = [
@@ -43,5 +44,32 @@ cc_library(
         "@com_github_googleapis_google_cloud_cpp_common//google/cloud/grpc_utils:google_cloud_cpp_grpc_utils",
 	"@com_google_googleapis//:bigquery_protos",
     ],
-
 )
+
+# TODO(#17): Use CMake-generated lists of files for this rule.
+cc_library(
+  name = "bigquery_client_mocks",
+  srcs = [],
+  hdrs = [
+      "testing/mock_bigquerystorage_stub.h",
+  ],
+  deps = [
+      ":bigquery_client",
+      "@com_github_googleapis_google_cloud_cpp//google/cloud:google_cloud_cpp_common",
+      "@com_github_googleapis_google_cloud_cpp//google/cloud/testing_util:google_cloud_cpp_testing",
+      "@com_google_googletest//:gtest",
+  ],
+)
+
+load(":bigquery_client_unit_tests.bzl", "bigquery_client_unit_tests")
+
+[cc_test(
+    name = "bigquery_client_" + test.replace("/", "_").replace(".cc", ""),
+    srcs = [test],
+    deps = [
+        ":bigquery_client",
+	":bigquery_client_mocks",
+        "@com_github_googleapis_google_cloud_cpp//google/cloud:google_cloud_cpp_common",
+        "@com_github_googleapis_google_cloud_cpp//google/cloud/testing_util:google_cloud_cpp_testing",
+        "@com_google_googletest//:gtest",
+    ]) for test in bigquery_client_unit_tests]

--- a/google/cloud/bigquery/CMakeLists.txt
+++ b/google/cloud/bigquery/CMakeLists.txt
@@ -95,12 +95,14 @@ add_library(bigquery_client
             internal/connection_impl.cc
             internal/connection_impl.h
             internal/stream_reader.h
+            internal/streaming_read_result_source.cc
+            internal/streaming_read_result_source.h
             read_result.h
             read_stream.h
             read_stream.cc
             row.h
             row_set.h
-            testing/mock_bigquerystorage_stub.cc
+            testing/mock_bigquerystorage_stub.h
             version.cc
             version.h
             version_info.h
@@ -141,7 +143,7 @@ function (bigquery_client_define_tests)
     find_package(google_cloud_cpp_testing CONFIG REQUIRED)
 
     set(bigquery_client_unit_tests
-        internal/bigquerystorage_stub_test.cc
+        internal/connection_impl_test.cc
         )
 
     # Export the list of unit tests to a .bzl file so we do not need to maintain

--- a/google/cloud/bigquery/CMakeLists.txt
+++ b/google/cloud/bigquery/CMakeLists.txt
@@ -100,9 +100,11 @@ add_library(bigquery_client
             read_stream.cc
             row.h
             row_set.h
+            testing/mock_bigquerystorage_stub.cc
             version.cc
             version.h
-            version_info.h)
+            version_info.h
+	    )
 target_include_directories(bigquery_client
                            PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
                                   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
@@ -139,6 +141,7 @@ function (bigquery_client_define_tests)
     find_package(google_cloud_cpp_testing CONFIG REQUIRED)
 
     set(bigquery_client_unit_tests
+        internal/bigquerystorage_stub_test.cc
         )
 
     # Export the list of unit tests to a .bzl file so we do not need to maintain

--- a/google/cloud/bigquery/CMakeLists.txt
+++ b/google/cloud/bigquery/CMakeLists.txt
@@ -95,6 +95,11 @@ add_library(bigquery_client
             internal/connection_impl.cc
             internal/connection_impl.h
             internal/stream_reader.h
+            read_result.h
+            read_stream.h
+            read_stream.cc
+            row.h
+            row_set.h
             version.cc
             version.h
             version_info.h)

--- a/google/cloud/bigquery/bigquery_client.bzl
+++ b/google/cloud/bigquery/bigquery_client.bzl
@@ -23,6 +23,10 @@ bigquery_client_hdrs = [
     "internal/bigquerystorage_stub.h",
     "internal/connection_impl.h",
     "internal/stream_reader.h",
+    "read_result.h",
+    "read_stream.h",
+    "row.h",
+    "row_set.h",
     "version.h",
     "version_info.h",
 ]
@@ -32,5 +36,6 @@ bigquery_client_srcs = [
     "connection_options.cc",
     "internal/bigquerystorage_stub.cc",
     "internal/connection_impl.cc",
+    "read_stream.cc",
     "version.cc",
 ]

--- a/google/cloud/bigquery/bigquery_client.bzl
+++ b/google/cloud/bigquery/bigquery_client.bzl
@@ -23,10 +23,12 @@ bigquery_client_hdrs = [
     "internal/bigquerystorage_stub.h",
     "internal/connection_impl.h",
     "internal/stream_reader.h",
+    "internal/streaming_read_result_source.h",
     "read_result.h",
     "read_stream.h",
     "row.h",
     "row_set.h",
+    "testing/mock_bigquerystorage_stub.h",
     "version.h",
     "version_info.h",
 ]
@@ -36,6 +38,7 @@ bigquery_client_srcs = [
     "connection_options.cc",
     "internal/bigquerystorage_stub.cc",
     "internal/connection_impl.cc",
+    "internal/streaming_read_result_source.cc",
     "read_stream.cc",
     "version.cc",
 ]

--- a/google/cloud/bigquery/bigquery_client_unit_tests.bzl
+++ b/google/cloud/bigquery/bigquery_client_unit_tests.bzl
@@ -17,4 +17,5 @@
 """Automatically generated unit tests list - DO NOT EDIT."""
 
 bigquery_client_unit_tests = [
+    "internal/connection_impl_test.cc",
 ]

--- a/google/cloud/bigquery/client.cc
+++ b/google/cloud/bigquery/client.cc
@@ -36,11 +36,9 @@ ReadResult<Row> Client::Read(std::string /*parent_project_id*/,
   return {};
 }
 
-ReadResult<Row> Client::Read(ReadStream<Row> const& /*read_stream*/) {
-  return {};
-}
+ReadResult<Row> Client::Read(ReadStream const& /*read_stream*/) { return {}; }
 
-StatusOr<std::vector<ReadStream<Row>>> Client::ParallelRead(
+StatusOr<std::vector<ReadStream>> Client::ParallelRead(
     std::string /*parent_project_id*/, std::string /*table*/,
     std::vector<std::string> /*columns*/) {
   return {};

--- a/google/cloud/bigquery/client.cc
+++ b/google/cloud/bigquery/client.cc
@@ -25,21 +25,20 @@ namespace bigquery {
 inline namespace BIGQUERY_CLIENT_NS {
 using ::google::cloud::StatusOr;
 
-ReadResult<Row> Client::Read(std::string /*parent_project_id*/,
-                             std::string /*table*/,
-                             std::vector<std::string> /*columns*/) {
+ReadResult Client::Read(std::string const& /*parent_project_id*/,
+                        std::string const& /*table*/,
+                        std::vector<std::string> const& /*columns*/) {
   return {};
 }
 
-ReadResult<Row> Client::Read(ReadStream const& read_stream) {
+ReadResult Client::Read(ReadStream const& read_stream) {
   return conn_->Read(read_stream);
 }
 
 StatusOr<std::vector<ReadStream>> Client::ParallelRead(
-    std::string parent_project_id, std::string table,
-    std::vector<std::string> columns) {
-  return conn_->ParallelRead(std::move(parent_project_id), std::move(table),
-                             std::move(columns));
+    std::string const& parent_project_id, std::string const& table,
+    std::vector<std::string> const& columns) {
+  return conn_->ParallelRead(parent_project_id, table, columns);
 }
 
 std::shared_ptr<Connection> MakeConnection(ConnectionOptions const& options) {

--- a/google/cloud/bigquery/client.cc
+++ b/google/cloud/bigquery/client.cc
@@ -25,11 +25,6 @@ namespace bigquery {
 inline namespace BIGQUERY_CLIENT_NS {
 using ::google::cloud::StatusOr;
 
-StatusOr<std::string> Client::CreateSession(std::string parent_project_id,
-                                            std::string table) {
-  return conn_->CreateSession(parent_project_id, table);
-}
-
 ReadResult<Row> Client::Read(std::string /*parent_project_id*/,
                              std::string /*table*/,
                              std::vector<std::string> /*columns*/) {
@@ -39,9 +34,10 @@ ReadResult<Row> Client::Read(std::string /*parent_project_id*/,
 ReadResult<Row> Client::Read(ReadStream const& /*read_stream*/) { return {}; }
 
 StatusOr<std::vector<ReadStream>> Client::ParallelRead(
-    std::string /*parent_project_id*/, std::string /*table*/,
-    std::vector<std::string> /*columns*/) {
-  return {};
+    std::string parent_project_id, std::string table,
+    std::vector<std::string> columns) {
+  return conn_->ParallelRead(std::move(parent_project_id), std::move(table),
+                             std::move(columns));
 }
 
 std::shared_ptr<Connection> MakeConnection(ConnectionOptions const& options) {

--- a/google/cloud/bigquery/client.cc
+++ b/google/cloud/bigquery/client.cc
@@ -31,7 +31,9 @@ ReadResult<Row> Client::Read(std::string /*parent_project_id*/,
   return {};
 }
 
-ReadResult<Row> Client::Read(ReadStream const& /*read_stream*/) { return {}; }
+ReadResult<Row> Client::Read(ReadStream const& read_stream) {
+  return conn_->Read(read_stream);
+}
 
 StatusOr<std::vector<ReadStream>> Client::ParallelRead(
     std::string parent_project_id, std::string table,

--- a/google/cloud/bigquery/client.h
+++ b/google/cloud/bigquery/client.h
@@ -46,13 +46,6 @@ class Client {
 
   friend bool operator!=(Client const& a, Client const& b) { return !(a == b); }
 
-  // Creates a new read session and returns its name if successful.
-  //
-  // This function is just a proof of concept to ensure we can send
-  // requests to the server.
-  StatusOr<std::string> CreateSession(std::string parent_project_id,
-                                      std::string table);
-
   // Reads the given table.
   //
   // The read is performed on behalf of `parent_project_id`.

--- a/google/cloud/bigquery/client.h
+++ b/google/cloud/bigquery/client.h
@@ -15,112 +15,19 @@
 #ifndef BIGQUERY_CLIENT_H_
 #define BIGQUERY_CLIENT_H_
 
-#include <memory>
-
 #include "google/cloud/bigquery/connection.h"
 #include "google/cloud/bigquery/connection_options.h"
+#include "google/cloud/bigquery/read_result.h"
+#include "google/cloud/bigquery/read_stream.h"
+#include "google/cloud/bigquery/row.h"
 #include "google/cloud/bigquery/version.h"
 #include "google/cloud/status_or.h"
+#include <memory>
 
 namespace google {
 namespace cloud {
 namespace bigquery {
 inline namespace BIGQUERY_CLIENT_NS {
-
-// TODO(aryann): Move all of the classes defined here except Client to their own
-// files.
-
-// TODO(aryann): Add an implementation for a row. We must support schemas that
-// are known at compile-time as well as those that are known at run-time.
-class Row {};
-
-template <typename RowType>
-class RowSet {
- public:
-  using value_type = StatusOr<RowType>;
-  class iterator {
-   public:
-    using iterator_category = std::input_iterator_tag;
-    using value_type = RowSet::value_type;
-    using difference_type = std::ptrdiff_t;
-    using pointer = value_type*;
-    using reference = value_type&;
-
-    reference operator*() { return curr_; }
-    pointer operator->() { return &curr_; }
-
-    iterator& operator++() { return *this; }
-
-    iterator operator++(int) { return {}; }
-
-    friend bool operator==(iterator const& , iterator const& ) { return {}; }
-
-    friend bool operator!=(iterator const& a, iterator const& b) {
-      return !(a == b);
-    }
-
-   private:
-    StatusOr<RowType> curr_;
-  };
-
-  iterator begin() { return {}; }
-
-  iterator end() { return {}; }
-};
-
-// Represents the result of a read operation.
-//
-// Note that at most one pass can be made over the data returned from a
-// `ReadResult`.
-template <typename RowType>
-class ReadResult {
- public:
-  // Returns a `RowSet` which can be used to iterate through the rows that are
-  // presented by this object.
-  RowSet<RowType> Rows() { return {}; }
-
-  // Returns a zero-based index of the last row returned by the `Rows()`
-  // iterator. If no rows have been read yet, returns -1.
-  int CurrentOffset() { return {}; }
-
-  // Returns a value between 0 and 1, inclusive, that indicates the progress in
-  // the result set based on the number of rows the server has processed.
-  //
-  // Note that if this ReadResult was created through
-  // `bigquery::Client::ParallelRead()` or if a row filter was provided, then
-  // the returned value will not necessarily equal to the current offset divided
-  // by the number of rows in the `ReadResult`:
-  //
-  //   * In the case of a parallel read, data are assigned to
-  //     `bigquery::ReadStream`s lazily by the server. The server does not know
-  //     the total number of rows that will be assigned to the stream ahead of
-  //     time, so it uses a denominator that is guaranteed to never exceed the
-  //     maximum number of rows that are allowed to be assigned.
-  //
-  //   * In the presence of a row filter, the denominator is not known until all
-  //     rows are read because some rows may be excluded. As such, the server
-  //     uses an estimate for the number of pre-filtering rows.
-  //
-  double FractionConsumed() { return {}; }
-};
-
-template <typename RowType>
-class ReadStream {};
-
-// Serializes an instance of `ReadStream` for transmission to another process.
-template <typename RowType>
-StatusOr<std::string> SerializeReadStream(
-    ReadStream<RowType> const& /*read_stream*/) {
-  return {};
-}
-
-// Deserializes the provided string to a `ReadStream`, if able.
-template <typename RowType>
-StatusOr<ReadStream<RowType>> DeserializeReadStream(
-    std::string /*serialized_read_stream*/) {
-  return {};
-}
-
 class Client {
  public:
   explicit Client(std::shared_ptr<Connection> conn) : conn_(std::move(conn)) {}
@@ -159,7 +66,7 @@ class Client {
   // Performs a read using a `ReadStream` returned by
   // `bigquery::Client::ParallelRead()`. See the documentation of
   // `ParallelRead()` for more information.
-  ReadResult<Row> Read(ReadStream<Row> const& read_stream);
+  ReadResult<Row> Read(ReadStream const& read_stream);
 
   // Creates one or more `ReadStream`s that can be used to read data from a
   // table in parallel.
@@ -171,7 +78,7 @@ class Client {
   // guaranteed to produce the same distribution or order of rows.
   //
   // After 24 hours, all `ReadStreams` created will stop working.
-  StatusOr<std::vector<ReadStream<Row>>> ParallelRead(
+  StatusOr<std::vector<ReadStream>> ParallelRead(
       std::string parent_project_id, std::string table,
       std::vector<std::string> columns = {});
 

--- a/google/cloud/bigquery/client.h
+++ b/google/cloud/bigquery/client.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef BIGQUERY_CLIENT_H_
-#define BIGQUERY_CLIENT_H_
+#ifndef GOOGLE_CLOUD_BIGQUERY_CLIENT_H_
+#define GOOGLE_CLOUD_BIGQUERY_CLIENT_H_
 
 #include "google/cloud/bigquery/connection.h"
 #include "google/cloud/bigquery/connection_options.h"
@@ -86,4 +86,4 @@ std::shared_ptr<Connection> MakeConnection(ConnectionOptions const& options);
 }  // namespace cloud
 }  // namespace google
 
-#endif  // BIGQUERY_CLIENT_H_
+#endif  // GOOGLE_CLOUD_BIGQUERY_CLIENT_H_

--- a/google/cloud/bigquery/client.h
+++ b/google/cloud/bigquery/client.h
@@ -53,13 +53,14 @@ class Client {
   // `table` must be in the form `PROJECT_ID:DATASET_ID.TABLE_ID`.
   //
   // There are no row ordering guarantees.
-  ReadResult<Row> Read(std::string parent_project_id, std::string table,
-                       std::vector<std::string> columns = {});
+  ReadResult Read(std::string const& parent_project_id,
+                  std::string const& table,
+                  std::vector<std::string> const& columns = {});
 
   // Performs a read using a `ReadStream` returned by
   // `bigquery::Client::ParallelRead()`. See the documentation of
   // `ParallelRead()` for more information.
-  ReadResult<Row> Read(ReadStream const& read_stream);
+  ReadResult Read(ReadStream const& read_stream);
 
   // Creates one or more `ReadStream`s that can be used to read data from a
   // table in parallel.
@@ -72,8 +73,8 @@ class Client {
   //
   // After 24 hours, all `ReadStreams` created will stop working.
   StatusOr<std::vector<ReadStream>> ParallelRead(
-      std::string parent_project_id, std::string table,
-      std::vector<std::string> columns = {});
+      std::string const& parent_project_id, std::string const& table,
+      std::vector<std::string> const& columns = {});
 
  private:
   std::shared_ptr<Connection> conn_;

--- a/google/cloud/bigquery/connection.h
+++ b/google/cloud/bigquery/connection.h
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef BIGQUERY_CONNECTION_H_
-#define BIGQUERY_CONNECTION_H_
+#ifndef GOOGLE_CLOUD_BIGQUERY_CONNECTION_H_
+#define GOOGLE_CLOUD_BIGQUERY_CONNECTION_H_
 
+#include "google/cloud/bigquery/read_result.h"
 #include "google/cloud/bigquery/read_stream.h"
 #include "google/cloud/bigquery/row.h"
 #include "google/cloud/bigquery/version.h"
@@ -29,6 +30,8 @@ class Connection {
  public:
   virtual ~Connection() = default;
 
+  virtual ReadResult<Row> Read(ReadStream const& read_stream) = 0;
+
   virtual StatusOr<std::vector<ReadStream>> ParallelRead(
       std::string parent_project_id, std::string table,
       std::vector<std::string> columns = {}) = 0;
@@ -39,4 +42,4 @@ class Connection {
 }  // namespace cloud
 }  // namespace google
 
-#endif  // BIGQUERY_CONNECTION_H_
+#endif  // GOOGLE_CLOUD_BIGQUERY_CONNECTION_H_

--- a/google/cloud/bigquery/connection.h
+++ b/google/cloud/bigquery/connection.h
@@ -29,8 +29,9 @@ class Connection {
  public:
   virtual ~Connection() = default;
 
-  virtual google::cloud::StatusOr<std::string> CreateSession(
-      std::string parent_project_id, std::string table) = 0;
+  virtual StatusOr<std::vector<ReadStream>> ParallelRead(
+      std::string parent_project_id, std::string table,
+      std::vector<std::string> columns = {}) = 0;
 };
 
 }  // namespace BIGQUERY_CLIENT_NS

--- a/google/cloud/bigquery/connection.h
+++ b/google/cloud/bigquery/connection.h
@@ -30,11 +30,11 @@ class Connection {
  public:
   virtual ~Connection() = default;
 
-  virtual ReadResult<Row> Read(ReadStream const& read_stream) = 0;
+  virtual ReadResult Read(ReadStream const& read_stream) = 0;
 
   virtual StatusOr<std::vector<ReadStream>> ParallelRead(
-      std::string parent_project_id, std::string table,
-      std::vector<std::string> columns = {}) = 0;
+      std::string const& parent_project_id, std::string const& table,
+      std::vector<std::string> const& columns = {}) = 0;
 };
 
 }  // namespace BIGQUERY_CLIENT_NS

--- a/google/cloud/bigquery/connection_options.cc
+++ b/google/cloud/bigquery/connection_options.cc
@@ -13,13 +13,10 @@
 // limitations under the License.
 
 #include "google/cloud/bigquery/connection_options.h"
-
+#include "google/cloud/bigquery/version.h"
 #include <grpcpp/grpcpp.h>
-
 #include <memory>
 #include <string>
-
-#include "google/cloud/bigquery/version.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigquery/connection_options.h
+++ b/google/cloud/bigquery/connection_options.h
@@ -15,12 +15,10 @@
 #ifndef BIGQUERY_CONNECTION_OPTIONS_H_
 #define BIGQUERY_CONNECTION_OPTIONS_H_
 
+#include "google/cloud/bigquery/version.h"
 #include <grpcpp/grpcpp.h>
-
 #include <memory>
 #include <string>
-
-#include "google/cloud/bigquery/version.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigquery/internal/bigquerystorage_stub.cc
+++ b/google/cloud/bigquery/internal/bigquerystorage_stub.cc
@@ -13,13 +13,6 @@
 // limitations under the License.
 
 #include "google/cloud/bigquery/internal/bigquerystorage_stub.h"
-
-#include <google/cloud/bigquery/storage/v1beta1/storage.grpc.pb.h>
-#include <google/cloud/bigquery/storage/v1beta1/storage.pb.h>
-#include <grpcpp/create_channel.h>
-
-#include <memory>
-
 #include "google/cloud/bigquery/connection.h"
 #include "google/cloud/bigquery/connection_options.h"
 #include "google/cloud/bigquery/internal/stream_reader.h"
@@ -27,6 +20,10 @@
 #include "google/cloud/grpc_utils/grpc_error_delegate.h"
 #include "google/cloud/optional.h"
 #include "google/cloud/status_or.h"
+#include <google/cloud/bigquery/storage/v1beta1/storage.grpc.pb.h>
+#include <google/cloud/bigquery/storage/v1beta1/storage.pb.h>
+#include <grpcpp/create_channel.h>
+#include <memory>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigquery/internal/bigquerystorage_stub.h
+++ b/google/cloud/bigquery/internal/bigquerystorage_stub.h
@@ -15,15 +15,13 @@
 #ifndef BIGQUERY_INTERNAL_BIGQUERY_READ_STUB_H_
 #define BIGQUERY_INTERNAL_BIGQUERY_READ_STUB_H_
 
-#include <google/cloud/bigquery/storage/v1beta1/storage.pb.h>
-
-#include <memory>
-
 #include "google/cloud/bigquery/connection.h"
 #include "google/cloud/bigquery/connection_options.h"
 #include "google/cloud/bigquery/internal/stream_reader.h"
 #include "google/cloud/bigquery/version.h"
 #include "google/cloud/status_or.h"
+#include <google/cloud/bigquery/storage/v1beta1/storage.pb.h>
+#include <memory>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigquery/internal/build_info.cc
+++ b/google/cloud/bigquery/internal/build_info.cc
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2017 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,30 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef BIGQUERY_CONNECTION_H_
-#define BIGQUERY_CONNECTION_H_
-
-#include "google/cloud/bigquery/read_stream.h"
-#include "google/cloud/bigquery/row.h"
-#include "google/cloud/bigquery/version.h"
-#include "google/cloud/status_or.h"
-#include <vector>
+#include "google/cloud/bigquery/internal/build_info.h"
+#include "google/cloud/internal/port_platform.h"
+#include <algorithm>
+#include <cctype>
+#include <iterator>
 
 namespace google {
 namespace cloud {
 namespace bigquery {
 inline namespace BIGQUERY_CLIENT_NS {
-class Connection {
- public:
-  virtual ~Connection() = default;
+namespace internal {
 
-  virtual google::cloud::StatusOr<std::string> CreateSession(
-      std::string parent_project_id, std::string table) = 0;
-};
+std::string BuildFlags() {
+  static auto const* const kFlags = [] {
+    auto* flags = new std::string(R"""()""");
+    if (!flags->empty()) {
+      *flags += ' ';
+    }
+    *flags +=
+        R"""()""";
+    return flags;
+  }();
+  return *kFlags;
+}
 
+std::string BuildMetadata() { return R"""(2ebb053)"""; }
+
+}  // namespace internal
 }  // namespace BIGQUERY_CLIENT_NS
 }  // namespace bigquery
 }  // namespace cloud
 }  // namespace google
-
-#endif  // BIGQUERY_CONNECTION_H_

--- a/google/cloud/bigquery/internal/connection_impl.cc
+++ b/google/cloud/bigquery/internal/connection_impl.cc
@@ -13,16 +13,13 @@
 // limitations under the License.
 
 #include "google/cloud/bigquery/internal/connection_impl.h"
-
-#include <google/cloud/bigquery/storage/v1beta1/storage.pb.h>
-
-#include <memory>
-#include <sstream>
-#include <string>
-
 #include "google/cloud/bigquery/internal/bigquerystorage_stub.h"
 #include "google/cloud/bigquery/version.h"
 #include "google/cloud/status_or.h"
+#include <google/cloud/bigquery/storage/v1beta1/storage.pb.h>
+#include <memory>
+#include <sstream>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigquery/internal/connection_impl.h
+++ b/google/cloud/bigquery/internal/connection_impl.h
@@ -33,6 +33,8 @@ namespace internal {
 // transport-related logic (e.g., any gRPC-specific code).
 class ConnectionImpl : public Connection {
  public:
+  ReadResult<Row> Read(ReadStream const& read_stream) override;
+
   StatusOr<std::vector<ReadStream>> ParallelRead(
       std::string parent_project_id, std::string table,
       std::vector<std::string> columns = {}) override;

--- a/google/cloud/bigquery/internal/connection_impl.h
+++ b/google/cloud/bigquery/internal/connection_impl.h
@@ -33,13 +33,19 @@ namespace internal {
 // transport-related logic (e.g., any gRPC-specific code).
 class ConnectionImpl : public Connection {
  public:
-  google::cloud::StatusOr<std::string> CreateSession(
-      std::string parent_project_id, std::string table) override;
+  StatusOr<std::vector<ReadStream>> ParallelRead(
+      std::string parent_project_id, std::string table,
+      std::vector<std::string> columns = {}) override;
 
  private:
   friend std::shared_ptr<ConnectionImpl> MakeConnection(
       std::shared_ptr<BigQueryStorageStub> read_stub);
   ConnectionImpl(std::shared_ptr<BigQueryStorageStub> read_stub);
+
+  google::cloud::StatusOr<
+      google::cloud::bigquery::storage::v1beta1::ReadSession>
+  NewReadSession(std::string parent_project_id, std::string table,
+                 std::vector<std::string> columns = {});
 
   std::shared_ptr<BigQueryStorageStub> read_stub_;
 };

--- a/google/cloud/bigquery/internal/connection_impl.h
+++ b/google/cloud/bigquery/internal/connection_impl.h
@@ -33,11 +33,11 @@ namespace internal {
 // transport-related logic (e.g., any gRPC-specific code).
 class ConnectionImpl : public Connection {
  public:
-  ReadResult<Row> Read(ReadStream const& read_stream) override;
+  ReadResult Read(ReadStream const& read_stream) override;
 
   StatusOr<std::vector<ReadStream>> ParallelRead(
-      std::string parent_project_id, std::string table,
-      std::vector<std::string> columns = {}) override;
+      std::string const& parent_project_id, std::string const& table,
+      std::vector<std::string> const& columns = {}) override;
 
  private:
   friend std::shared_ptr<ConnectionImpl> MakeConnection(
@@ -46,8 +46,8 @@ class ConnectionImpl : public Connection {
 
   google::cloud::StatusOr<
       google::cloud::bigquery::storage::v1beta1::ReadSession>
-  NewReadSession(std::string parent_project_id, std::string table,
-                 std::vector<std::string> columns = {});
+  NewReadSession(std::string const& parent_project_id, std::string const& table,
+                 std::vector<std::string> const& columns = {});
 
   std::shared_ptr<BigQueryStorageStub> read_stub_;
 };

--- a/google/cloud/bigquery/internal/connection_impl.h
+++ b/google/cloud/bigquery/internal/connection_impl.h
@@ -15,12 +15,11 @@
 #ifndef BIGQUERY_INTERNAL_CONNECTION_H_
 #define BIGQUERY_INTERNAL_CONNECTION_H_
 
-#include <memory>
-
 #include "google/cloud/bigquery/connection.h"
 #include "google/cloud/bigquery/internal/bigquerystorage_stub.h"
 #include "google/cloud/bigquery/version.h"
 #include "google/cloud/status_or.h"
+#include <memory>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigquery/internal/connection_impl_test.cc
+++ b/google/cloud/bigquery/internal/connection_impl_test.cc
@@ -1,0 +1,124 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigquery/internal/connection_impl.h"
+#include "google/cloud/bigquery/internal/bigquerystorage_stub.h"
+#include "google/cloud/bigquery/testing/mock_bigquerystorage_stub.h"
+#include "google/cloud/bigquery/version.h"
+#include "google/cloud/status_or.h"
+#include <google/cloud/bigquery/storage/v1beta1/storage.pb.h>
+#include <google/protobuf/text_format.h>
+#include <gmock/gmock.h>
+#include <memory>
+#include <sstream>
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace bigquery {
+inline namespace BIGQUERY_CLIENT_NS {
+namespace internal {
+namespace {
+
+namespace bigquerystorage_proto = ::google::cloud::bigquery::storage::v1beta1;
+
+using ::google::cloud::Status;
+using ::google::cloud::StatusCode;
+using ::google::cloud::StatusOr;
+using ::google::protobuf::TextFormat;
+using ::testing::_;
+using ::testing::ElementsAre;
+using ::testing::Eq;
+using ::testing::IsTrue;
+
+TEST(ConnectionImplTest, ParallelReadTableFailure) {
+  auto mock = std::make_shared<bigquery_testing::MockBigQueryStorageStub>();
+  auto conn = MakeConnection(mock);
+
+  {
+    StatusOr<std::vector<ReadStream>> result = conn->ParallelRead(
+        "my-parent-project", "my-project.my-dataset.my-table");
+    EXPECT_THAT(result.status().code(), Eq(StatusCode::kInvalidArgument));
+    EXPECT_THAT(
+        result.status().message(),
+        Eq("Table name must be of the form PROJECT_ID:DATASET_ID.TABLE_ID."));
+  }
+
+  {
+    StatusOr<std::vector<ReadStream>> result = conn->ParallelRead(
+        "my-parent-project", "my-project:my-dataset:my-table");
+    EXPECT_THAT(result.status().code(), Eq(StatusCode::kInvalidArgument));
+    EXPECT_THAT(
+        result.status().message(),
+        Eq("Table name must be of the form PROJECT_ID:DATASET_ID.TABLE_ID."));
+  }
+}
+
+TEST(ConnectionImplTest, ParallelReadRpcFailure) {
+  auto mock = std::make_shared<bigquery_testing::MockBigQueryStorageStub>();
+  auto conn = MakeConnection(mock);
+  EXPECT_CALL(*mock, CreateReadSession(_))
+      .WillOnce(testing::Invoke(
+          [](bigquerystorage_proto::CreateReadSessionRequest const& request) {
+            return Status(StatusCode::kPermissionDenied, "Permission denied!");
+          }));
+
+  StatusOr<std::vector<ReadStream>> result =
+      conn->ParallelRead("my-parent-project", "my-project:my-dataset.my-table");
+  EXPECT_THAT(result.status().code(), Eq(StatusCode::kPermissionDenied));
+  EXPECT_THAT(result.status().message(), Eq("Permission denied!"));
+}
+
+TEST(ConnectionImplTest, ParallelReadRpcSuccess) {
+  auto mock = std::make_shared<bigquery_testing::MockBigQueryStorageStub>();
+  auto conn = MakeConnection(mock);
+  EXPECT_CALL(*mock, CreateReadSession(_))
+      .WillOnce(testing::Invoke(
+          [](bigquerystorage_proto::CreateReadSessionRequest const& request)
+              -> StatusOr<bigquerystorage_proto::ReadSession> {
+            EXPECT_THAT(request.parent(), Eq("projects/my-parent-project"));
+            EXPECT_THAT(request.table_reference().project_id(),
+                        Eq("my-project"));
+            EXPECT_THAT(request.table_reference().dataset_id(),
+                        Eq("my-dataset"));
+            EXPECT_THAT(request.table_reference().table_id(), Eq("my-table"));
+            EXPECT_THAT(request.read_options().selected_fields(0), Eq("col-0"));
+            EXPECT_THAT(request.read_options().selected_fields(1), Eq("col-1"));
+
+            bigquerystorage_proto::ReadSession response;
+            EXPECT_TRUE(TextFormat::ParseFromString(
+                R"pb(
+                  name: "my-session"
+                  streams {name: "stream-0"}
+                  streams {name: "stream-1"}
+                  streams {name: "stream-2"}
+                )pb", &response));
+            return response;
+          }));
+
+  StatusOr<std::vector<ReadStream>> result =
+      conn->ParallelRead("my-parent-project", "my-project:my-dataset.my-table",
+                         {"col-0", "col-1"});
+  EXPECT_THAT(result.ok(), IsTrue());
+  EXPECT_THAT(result.value(), ElementsAre(MakeReadStream("stream-0"),
+                                          MakeReadStream("stream-1"),
+                                          MakeReadStream("stream-2")));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace BIGQUERY_CLIENT_NS
+}  // namespace bigquery
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigquery/internal/connection_impl_test.cc
+++ b/google/cloud/bigquery/internal/connection_impl_test.cc
@@ -69,8 +69,9 @@ TEST(ConnectionImplTest, ParallelReadRpcFailure) {
   auto mock = std::make_shared<bigquery_testing::MockBigQueryStorageStub>();
   auto conn = MakeConnection(mock);
   EXPECT_CALL(*mock, CreateReadSession(_))
-      .WillOnce(testing::Invoke(
-          [](bigquerystorage_proto::CreateReadSessionRequest const& /*request*/) {
+      .WillOnce(
+          testing::Invoke([](bigquerystorage_proto::
+                                 CreateReadSessionRequest const& /*request*/) {
             return Status(StatusCode::kPermissionDenied, "Permission denied!");
           }));
 
@@ -93,6 +94,8 @@ TEST(ConnectionImplTest, ParallelReadRpcSuccess) {
             EXPECT_THAT(request.table_reference().dataset_id(),
                         Eq("my-dataset"));
             EXPECT_THAT(request.table_reference().table_id(), Eq("my-table"));
+
+            EXPECT_THAT(request.read_options().selected_fields_size(), Eq(2));
             EXPECT_THAT(request.read_options().selected_fields(0), Eq("col-0"));
             EXPECT_THAT(request.read_options().selected_fields(1), Eq("col-1"));
 

--- a/google/cloud/bigquery/internal/connection_impl_test.cc
+++ b/google/cloud/bigquery/internal/connection_impl_test.cc
@@ -70,7 +70,7 @@ TEST(ConnectionImplTest, ParallelReadRpcFailure) {
   auto conn = MakeConnection(mock);
   EXPECT_CALL(*mock, CreateReadSession(_))
       .WillOnce(testing::Invoke(
-          [](bigquerystorage_proto::CreateReadSessionRequest const& request) {
+          [](bigquerystorage_proto::CreateReadSessionRequest const& /*request*/) {
             return Status(StatusCode::kPermissionDenied, "Permission denied!");
           }));
 

--- a/google/cloud/bigquery/internal/streaming_read_result_source.cc
+++ b/google/cloud/bigquery/internal/streaming_read_result_source.cc
@@ -1,0 +1,67 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigquery/internal/streaming_read_result_source.h"
+#include "google/cloud/bigquery/read_result.h"
+#include "google/cloud/bigquery/row.h"
+#include "google/cloud/bigquery/version.h"
+#include "google/cloud/optional.h"
+#include "google/cloud/status_or.h"
+#include <memory>
+
+namespace google {
+namespace cloud {
+namespace bigquery {
+inline namespace BIGQUERY_CLIENT_NS {
+namespace internal {
+
+namespace {
+namespace bigquerystorage_proto = ::google::cloud::bigquery::storage::v1beta1;
+}  // namespace
+
+StatusOr<optional<Row>> StreamingReadResultSource::NextRow() {
+  if (!curr_ || offset_in_curr_response_ == curr_->row_count()) {
+    // Either no response has ever been read from the server or the previous
+    // call to this function consumed the last row in the last response.
+    auto next = reader_->NextValue();
+    if (!next.ok()) {
+      return next.status();
+    }
+    if (!next.value()) {
+      return optional<Row>();
+    }
+    curr_ = std::move(next.value());
+    offset_in_curr_response_ = 0;
+  }
+
+  // TODO(#18): For now, we're just returning dummy Row objects, one per row in
+  // the response. Once we get Apache Arrow set up as a dependency, start
+  // parsing the actual data.
+  ++offset_in_curr_response_;
+  ++offset_;
+
+  bigquerystorage_proto::Progress const& progress = curr_->status().progress();
+  fraction_consumed_ =
+      progress.at_response_start() +
+      (progress.at_response_end() - progress.at_response_start()) *
+          offset_in_curr_response_ * 1.0 / curr_->row_count();
+
+  return optional<Row>(Row());
+}
+
+}  // namespace internal
+}  // namespace BIGQUERY_CLIENT_NS
+}  // namespace bigquery
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigquery/internal/streaming_read_result_source.h
+++ b/google/cloud/bigquery/internal/streaming_read_result_source.h
@@ -50,7 +50,7 @@ class StreamingReadResultSource : public ReadResultSource {
 
   optional<google::cloud::bigquery::storage::v1beta1::ReadRowsResponse> curr_;
   int offset_in_curr_response_;
-  int offset_;
+  std::size_t offset_;
   double fraction_consumed_;
 };
 

--- a/google/cloud/bigquery/internal/streaming_read_result_source.h
+++ b/google/cloud/bigquery/internal/streaming_read_result_source.h
@@ -49,7 +49,7 @@ class StreamingReadResultSource : public ReadResultSource {
       reader_;
 
   optional<google::cloud::bigquery::storage::v1beta1::ReadRowsResponse> curr_;
-  int offset_in_curr_response_;
+  std::int64_t offset_in_curr_response_;
   std::size_t offset_;
   double fraction_consumed_;
 };

--- a/google/cloud/bigquery/internal/streaming_read_result_source.h
+++ b/google/cloud/bigquery/internal/streaming_read_result_source.h
@@ -1,0 +1,63 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_BIGQUERY_INTERNAL_STREAMING_READ_RESULT_SOURCE_H_
+#define GOOGLE_CLOUD_BIGQUERY_INTERNAL_STREAMING_READ_RESULT_SOURCE_H_
+
+#include "google/cloud/bigquery/internal/stream_reader.h"
+#include "google/cloud/bigquery/read_result.h"
+#include "google/cloud/bigquery/version.h"
+#include "google/cloud/status_or.h"
+#include <google/cloud/bigquery/storage/v1beta1/storage.pb.h>
+#include <memory>
+
+namespace google {
+namespace cloud {
+namespace bigquery {
+inline namespace BIGQUERY_CLIENT_NS {
+namespace internal {
+
+class StreamingReadResultSource : public ReadResultSource {
+ public:
+  explicit StreamingReadResultSource(
+      std::unique_ptr<StreamReader<
+          google::cloud::bigquery::storage::v1beta1::ReadRowsResponse>>
+          reader)
+      : reader_(std::move(reader)),
+        offset_in_curr_response_(0),
+        offset_(0),
+        fraction_consumed_(0) {}
+
+  StatusOr<optional<Row>> NextRow() override;
+  int CurrentOffset() override { return offset_; }
+  double FractionConsumed() override { return fraction_consumed_; }
+
+ private:
+  std::unique_ptr<
+      StreamReader<google::cloud::bigquery::storage::v1beta1::ReadRowsResponse>>
+      reader_;
+
+  optional<google::cloud::bigquery::storage::v1beta1::ReadRowsResponse> curr_;
+  int offset_in_curr_response_;
+  int offset_;
+  double fraction_consumed_;
+};
+
+}  // namespace internal
+}  // namespace BIGQUERY_CLIENT_NS
+}  // namespace bigquery
+}  // namespace cloud
+}  // namespace google
+
+#endif  // BIGQUERY_INTERNAL_CONNECTION_H_

--- a/google/cloud/bigquery/internal/streaming_read_result_source.h
+++ b/google/cloud/bigquery/internal/streaming_read_result_source.h
@@ -40,7 +40,7 @@ class StreamingReadResultSource : public ReadResultSource {
         fraction_consumed_(0) {}
 
   StatusOr<optional<Row>> NextRow() override;
-  int CurrentOffset() override { return offset_; }
+  std::size_t CurrentOffset() override { return offset_; }
   double FractionConsumed() override { return fraction_consumed_; }
 
  private:

--- a/google/cloud/bigquery/read_result.h
+++ b/google/cloud/bigquery/read_result.h
@@ -31,7 +31,7 @@ class ReadResultSource {
  public:
   virtual ~ReadResultSource() = default;
   virtual StatusOr<optional<Row>> NextRow() = 0;
-  virtual int CurrentOffset() = 0;
+  virtual std::size_t CurrentOffset() = 0;
   virtual double FractionConsumed() = 0;
 };
 
@@ -41,7 +41,6 @@ class ReadResultSource {
 //
 // Note that at most one pass can be made over the data returned from a
 // `ReadResult`.
-template <typename RowType>
 class ReadResult {
  public:
   ReadResult() = default;
@@ -50,16 +49,17 @@ class ReadResult {
 
   // Returns a `RowSet` which can be used to iterate through the rows that are
   // presented by this object.
-  RowSet<RowType> Rows() {
-    return RowSet<RowType>([this]() mutable { return source_->NextRow(); });
+  RowSet<Row> Rows() {
+    return RowSet<Row>([this]() mutable { return source_->NextRow(); });
   }
 
   // Returns a zero-based index of the last row returned by the `Rows()`
   // iterator. If no rows have been read yet, returns -1.
   int CurrentOffset() { return source_->CurrentOffset(); }
 
-  // Returns a value between 0 and 1, inclusive, that indicates the progress in
-  // the result set based on the number of rows the server has processed.
+  // Returns a value between 0 and 1, inclusive, that indicates the estimated
+  // progress in the result set based on the number of rows the server has
+  // processed.
   //
   // Note that if this ReadResult was created through
   // `bigquery::Client::ParallelRead()` or if a row filter was provided, then

--- a/google/cloud/bigquery/read_result.h
+++ b/google/cloud/bigquery/read_result.h
@@ -1,0 +1,66 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_BIGQUERY_READ_RESULT_H_
+#define GOOGLE_CLOUD_BIGQUERY_READ_RESULT_H_
+
+#include "google/cloud/bigquery/row_set.h"
+#include "google/cloud/bigquery/version.h"
+
+namespace google {
+namespace cloud {
+namespace bigquery {
+inline namespace BIGQUERY_CLIENT_NS {
+// Represents the result of a read operation.
+//
+// Note that at most one pass can be made over the data returned from a
+// `ReadResult`.
+template <typename RowType>
+class ReadResult {
+ public:
+  // Returns a `RowSet` which can be used to iterate through the rows that are
+  // presented by this object.
+  RowSet<RowType> Rows() { return {}; }
+
+  // Returns a zero-based index of the last row returned by the `Rows()`
+  // iterator. If no rows have been read yet, returns -1.
+  int CurrentOffset() { return {}; }
+
+  // Returns a value between 0 and 1, inclusive, that indicates the progress in
+  // the result set based on the number of rows the server has processed.
+  //
+  // Note that if this ReadResult was created through
+  // `bigquery::Client::ParallelRead()` or if a row filter was provided, then
+  // the returned value will not necessarily equal to the current offset divided
+  // by the number of rows in the `ReadResult`:
+  //
+  //   * In the case of a parallel read, data are assigned to
+  //     `bigquery::ReadStream`s lazily by the server. The server does not know
+  //     the total number of rows that will be assigned to the stream ahead of
+  //     time, so it uses a denominator that is guaranteed to never exceed the
+  //     maximum number of rows that are allowed to be assigned.
+  //
+  //   * In the presence of a row filter, the denominator is not known until all
+  //     rows are read because some rows may be excluded. As such, the server
+  //     uses an estimate for the number of pre-filtering rows.
+  //
+  double FractionConsumed() { return {}; }
+};
+
+}  // namespace BIGQUERY_CLIENT_NS
+}  // namespace bigquery
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_BIGQUERY_READ_RESULT_H_

--- a/google/cloud/bigquery/read_stream.cc
+++ b/google/cloud/bigquery/read_stream.cc
@@ -20,6 +20,12 @@ namespace google {
 namespace cloud {
 namespace bigquery {
 inline namespace BIGQUERY_CLIENT_NS {
+namespace internal {
+ReadStream MakeReadStream(std::string stream_name) {
+  return ReadStream(std::move(stream_name));
+}
+}  // namespace internal
+
 StatusOr<std::string> SerializeReadStream(ReadStream const& /*read_stream*/) {
   return {};
 }

--- a/google/cloud/bigquery/read_stream.cc
+++ b/google/cloud/bigquery/read_stream.cc
@@ -12,30 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef BIGQUERY_CONNECTION_H_
-#define BIGQUERY_CONNECTION_H_
-
 #include "google/cloud/bigquery/read_stream.h"
-#include "google/cloud/bigquery/row.h"
 #include "google/cloud/bigquery/version.h"
 #include "google/cloud/status_or.h"
-#include <vector>
 
 namespace google {
 namespace cloud {
 namespace bigquery {
 inline namespace BIGQUERY_CLIENT_NS {
-class Connection {
- public:
-  virtual ~Connection() = default;
+StatusOr<std::string> SerializeReadStream(ReadStream const& /*read_stream*/) {
+  return {};
+}
 
-  virtual google::cloud::StatusOr<std::string> CreateSession(
-      std::string parent_project_id, std::string table) = 0;
-};
+StatusOr<ReadStream> DeserializeReadStream(
+    std::string /*serialized_read_stream*/) {
+  return {};
+}
 
 }  // namespace BIGQUERY_CLIENT_NS
 }  // namespace bigquery
 }  // namespace cloud
 }  // namespace google
-
-#endif  // BIGQUERY_CONNECTION_H_

--- a/google/cloud/bigquery/read_stream.cc
+++ b/google/cloud/bigquery/read_stream.cc
@@ -26,7 +26,7 @@ ReadStream MakeReadStream(std::string stream_name) {
 }
 }  // namespace internal
 
-StatusOr<std::string> SerializeReadStream(ReadStream const& /*read_stream*/) {
+std::string SerializeReadStream(ReadStream const& /*read_stream*/) {
   return {};
 }
 

--- a/google/cloud/bigquery/read_stream.h
+++ b/google/cloud/bigquery/read_stream.h
@@ -22,7 +22,35 @@ namespace google {
 namespace cloud {
 namespace bigquery {
 inline namespace BIGQUERY_CLIENT_NS {
-class ReadStream {};
+class ReadStream;
+
+namespace internal {
+ReadStream MakeReadStream(std::string stream_name);
+}  // namespace internal
+
+class ReadStream {
+ public:
+  ReadStream(ReadStream const&) = default;
+  ReadStream(ReadStream&&) = default;
+  ReadStream& operator=(ReadStream const&) = default;
+  ReadStream& operator=(ReadStream&&) = default;
+
+  std::string const& stream_name() const { return stream_name_; }
+
+  friend bool operator==(ReadStream const& lhs, ReadStream const& rhs) {
+    return lhs.stream_name_ == rhs.stream_name_;
+  }
+  friend bool operator!=(ReadStream const& lhs, ReadStream const& rhs) {
+    return !(lhs == rhs);
+  }
+
+ private:
+  friend ReadStream internal::MakeReadStream(std::string stream_name);
+  explicit ReadStream(std::string stream_name)
+      : stream_name_(std::move(stream_name)) {}
+
+  const std::string stream_name_;
+};
 
 // Serializes an instance of `ReadStream` for transmission to another process.
 StatusOr<std::string> SerializeReadStream(ReadStream const& /*read_stream*/);

--- a/google/cloud/bigquery/read_stream.h
+++ b/google/cloud/bigquery/read_stream.h
@@ -12,30 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef BIGQUERY_CONNECTION_H_
-#define BIGQUERY_CONNECTION_H_
+#ifndef GOOGLE_CLOUD_BIGQUERY_READ_STREAM_H_
+#define GOOGLE_CLOUD_BIGQUERY_READ_STREAM_H_
 
-#include "google/cloud/bigquery/read_stream.h"
-#include "google/cloud/bigquery/row.h"
 #include "google/cloud/bigquery/version.h"
 #include "google/cloud/status_or.h"
-#include <vector>
 
 namespace google {
 namespace cloud {
 namespace bigquery {
 inline namespace BIGQUERY_CLIENT_NS {
-class Connection {
- public:
-  virtual ~Connection() = default;
+class ReadStream {};
 
-  virtual google::cloud::StatusOr<std::string> CreateSession(
-      std::string parent_project_id, std::string table) = 0;
-};
+// Serializes an instance of `ReadStream` for transmission to another process.
+StatusOr<std::string> SerializeReadStream(ReadStream const& /*read_stream*/);
+
+// Deserializes the provided string to a `ReadStream`, if able.
+StatusOr<ReadStream> DeserializeReadStream(
+    std::string /*serialized_read_stream*/);
 
 }  // namespace BIGQUERY_CLIENT_NS
 }  // namespace bigquery
 }  // namespace cloud
 }  // namespace google
 
-#endif  // BIGQUERY_CONNECTION_H_
+#endif  // GOOGLE_CLOUD_BIGQUERY_READ_STREAM_H_

--- a/google/cloud/bigquery/read_stream.h
+++ b/google/cloud/bigquery/read_stream.h
@@ -49,11 +49,11 @@ class ReadStream {
   explicit ReadStream(std::string stream_name)
       : stream_name_(std::move(stream_name)) {}
 
-  const std::string stream_name_;
+  std::string stream_name_;
 };
 
 // Serializes an instance of `ReadStream` for transmission to another process.
-StatusOr<std::string> SerializeReadStream(ReadStream const& /*read_stream*/);
+std::string SerializeReadStream(ReadStream const& /*read_stream*/);
 
 // Deserializes the provided string to a `ReadStream`, if able.
 StatusOr<ReadStream> DeserializeReadStream(

--- a/google/cloud/bigquery/row.h
+++ b/google/cloud/bigquery/row.h
@@ -26,7 +26,17 @@ inline namespace BIGQUERY_CLIENT_NS {
 
 // TODO(aryann): Add an implementation for a row. We must support schemas that
 // are known at compile-time as well as those that are known at run-time.
-class Row {};
+class Row {
+ public:
+  Row() = default;
+
+  ~Row() = default;
+
+  Row(Row const&) = default;
+  Row& operator=(Row const&) = default;
+  Row(Row&&) = default;
+  Row& operator=(Row&&) = default;
+};
 
 }  // namespace BIGQUERY_CLIENT_NS
 }  // namespace bigquery

--- a/google/cloud/bigquery/row.h
+++ b/google/cloud/bigquery/row.h
@@ -12,30 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef BIGQUERY_CONNECTION_H_
-#define BIGQUERY_CONNECTION_H_
+#ifndef GOOGLE_CLOUD_BIGQUERY_ROW_H_
+#define GOOGLE_CLOUD_BIGQUERY_ROW_H_
 
-#include "google/cloud/bigquery/read_stream.h"
-#include "google/cloud/bigquery/row.h"
 #include "google/cloud/bigquery/version.h"
-#include "google/cloud/status_or.h"
-#include <vector>
 
 namespace google {
 namespace cloud {
 namespace bigquery {
 inline namespace BIGQUERY_CLIENT_NS {
-class Connection {
- public:
-  virtual ~Connection() = default;
+// TODO(aryann): Move all of the classes defined here except Client to their own
+// files.
 
-  virtual google::cloud::StatusOr<std::string> CreateSession(
-      std::string parent_project_id, std::string table) = 0;
-};
+// TODO(aryann): Add an implementation for a row. We must support schemas that
+// are known at compile-time as well as those that are known at run-time.
+class Row {};
 
 }  // namespace BIGQUERY_CLIENT_NS
 }  // namespace bigquery
 }  // namespace cloud
 }  // namespace google
 
-#endif  // BIGQUERY_CONNECTION_H_
+#endif  // GOOGLE_CLOUD_BIGQUERY_ROW_H_

--- a/google/cloud/bigquery/row_set.h
+++ b/google/cloud/bigquery/row_set.h
@@ -1,0 +1,70 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_BIGQUERY_ROW_SET_H_
+#define GOOGLE_CLOUD_BIGQUERY_ROW_SET_H_
+
+#include "google/cloud/bigquery/connection.h"
+#include "google/cloud/bigquery/connection_options.h"
+#include "google/cloud/bigquery/read_result.h"
+#include "google/cloud/bigquery/read_stream.h"
+#include "google/cloud/bigquery/row.h"
+#include "google/cloud/bigquery/version.h"
+#include "google/cloud/status_or.h"
+#include <memory>
+
+namespace google {
+namespace cloud {
+namespace bigquery {
+inline namespace BIGQUERY_CLIENT_NS {
+template <typename RowType>
+class RowSet {
+ public:
+  using value_type = StatusOr<RowType>;
+  class iterator {
+   public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = RowSet::value_type;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
+    reference operator*() { return curr_; }
+    pointer operator->() { return &curr_; }
+
+    iterator& operator++() { return *this; }
+
+    iterator operator++(int) { return {}; }
+
+    friend bool operator==(iterator const&, iterator const&) { return {}; }
+
+    friend bool operator!=(iterator const& a, iterator const& b) {
+      return !(a == b);
+    }
+
+   private:
+    StatusOr<RowType> curr_;
+  };
+
+  iterator begin() { return {}; }
+
+  iterator end() { return {}; }
+};
+
+}  // namespace BIGQUERY_CLIENT_NS
+}  // namespace bigquery
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_BIGQUERY_ROW_SET_H_

--- a/google/cloud/bigquery/row_set.h
+++ b/google/cloud/bigquery/row_set.h
@@ -64,7 +64,6 @@ class RowSet {
 
    private:
     friend RowSet;
-    iterator() = default;
     explicit iterator(std::function<StatusOr<optional<RowType>>()>* source)
         : source_(source) {
       if (source_) {

--- a/google/cloud/bigquery/samples/read.cc
+++ b/google/cloud/bigquery/samples/read.cc
@@ -33,9 +33,9 @@ using google::cloud::bigquery::SerializeReadStream;
 void SimpleRead() {
   ConnectionOptions options;
   Client client(MakeConnection(options));
-  ReadResult<Row> result = client.Read(
-      "my-parent-project", "bigquery-public-data:samples.shakespeare",
-      /* columns = */ {"c1", "c2", "c3"});
+  ReadResult result = client.Read("my-parent-project",
+                                  "bigquery-public-data:samples.shakespeare",
+                                  /* columns = */ {"c1", "c2", "c3"});
   for (StatusOr<Row> const& row : result.Rows()) {
     if (row.ok()) {
       // Do something with row.value();
@@ -55,14 +55,14 @@ void ParallelRead() {
   }
 
   for (ReadStream const& stream : read_session.value()) {
-    std::string bits = SerializeReadStream(stream).value();
+    std::string bits = SerializeReadStream(stream);
     // Send bits to worker job.
   }
 
   // From a worker job:
   std::string bits;  // Sent by coordinating job.
   ReadStream stream = DeserializeReadStream(bits).value();
-  ReadResult<Row> result = client.Read(stream);
+  ReadResult result = client.Read(stream);
   for (StatusOr<Row> const& row : result.Rows()) {
     if (row.ok()) {
       // Do something with row.value();
@@ -84,7 +84,7 @@ int CreateSession(std::string const& project_id) {
 
   for (ReadStream const& stream : res.value()) {
     std::cout << "Starting stream: " << stream.stream_name() << "\n";
-    ReadResult<Row> read_result = client.Read(stream);
+    ReadResult read_result = client.Read(stream);
     for (StatusOr<Row> const& row : read_result.Rows()) {
       if (!row.ok()) {
         std::cerr << "Error at row offset " << read_result.CurrentOffset()

--- a/google/cloud/bigquery/samples/read.cc
+++ b/google/cloud/bigquery/samples/read.cc
@@ -70,6 +70,22 @@ void ParallelRead() {
   }
 }
 
+void CreateSession(std::string const& project_id) {
+  google::cloud::bigquery::ConnectionOptions options;
+  google::cloud::bigquery::Client client(
+      google::cloud::bigquery::MakeConnection(options));
+  google::cloud::StatusOr<std::vector<ReadStream>> res = client.ParallelRead(
+      project_id, "bigquery-public-data:samples.shakespeare");
+
+  if (res.ok()) {
+    for (ReadStream const& stream : res.value()) {
+      std::cout << "Read stream: " << stream.stream_name() << "\n";
+    }
+  } else {
+    std::cerr << "Session creation failed with error: " << res.status() << "\n";
+  }
+}
+
 }  // namespace
 
 int main(int argc, char* argv[]) {
@@ -81,25 +97,12 @@ int main(int argc, char* argv[]) {
   std::string cmd = argv[1];
   std::string project_id = argv[2];
 
-  google::cloud::bigquery::ConnectionOptions options;
-  google::cloud::bigquery::Client client(
-      google::cloud::bigquery::MakeConnection(options));
-  google::cloud::StatusOr<std::string> res = client.CreateSession(
-      project_id, "bigquery-public-data:samples.shakespeare");
-
-  if (res.ok()) {
-    std::cout << "Session name: " << res.value() << "\n";
-  } else {
-    std::cerr << "Session creation failed with error: " << res.status() << "\n";
-    return EXIT_FAILURE;
-  }
-
   if (cmd == "SimpleRead") {
     SimpleRead();
   } else if (cmd == "ParallelRead") {
     ParallelRead();
-  } else if (cmd == "None") {
-    std::cout << "Doing nothing really fast\n";
+  } else if (cmd == "CreateSession") {
+    CreateSession(project_id);
   } else {
     std::cerr << "Unknown command: " << cmd << "\n";
     return EXIT_FAILURE;

--- a/google/cloud/bigquery/samples/read.cc
+++ b/google/cloud/bigquery/samples/read.cc
@@ -47,21 +47,21 @@ void ParallelRead() {
   // From coordinating job:
   ConnectionOptions options;
   Client client(MakeConnection(options));
-  StatusOr<std::vector<ReadStream<Row>>> read_session = client.ParallelRead(
+  StatusOr<std::vector<ReadStream>> read_session = client.ParallelRead(
       "my-parent-project", "bigquery-public-data:samples.shakespeare",
       /* columns = */ {"c1", "c2", "c3"});
   if (!read_session.ok()) {
     // Handle error;
   }
 
-  for (ReadStream<Row> const& stream : read_session.value()) {
+  for (ReadStream const& stream : read_session.value()) {
     std::string bits = SerializeReadStream(stream).value();
     // Send bits to worker job.
   }
 
   // From a worker job:
   std::string bits;  // Sent by coordinating job.
-  ReadStream<Row> stream = DeserializeReadStream<Row>(bits).value();
+  ReadStream stream = DeserializeReadStream(bits).value();
   ReadResult<Row> result = client.Read(stream);
   for (StatusOr<Row> const& row : result.Rows()) {
     if (row.ok()) {

--- a/google/cloud/bigquery/testing/mock_bigquerystorage_stub.h
+++ b/google/cloud/bigquery/testing/mock_bigquerystorage_stub.h
@@ -1,0 +1,50 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_BIGQUERY_TESTING_MOCK_BIGQUERY_READ_STUB_H_
+#define GOOGLE_CLOUD_BIGQUERY_TESTING_MOCK_BIGQUERY_READ_STUB_H_
+
+#include "google/cloud/bigquery/internal/bigquerystorage_stub.h"
+#include "google/cloud/bigquery/internal/stream_reader.h"
+#include "google/cloud/bigquery/version.h"
+#include "google/cloud/status_or.h"
+#include <google/cloud/bigquery/storage/v1beta1/storage.pb.h>
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace bigquery_testing {
+inline namespace BIGQUERY_CLIENT_NS {
+class MockBigQueryStorageStub
+    : public google::cloud::bigquery::internal::BigQueryStorageStub {
+ public:
+  MOCK_METHOD1(CreateReadSession,
+               google::cloud::StatusOr<
+                   google::cloud::bigquery::storage::v1beta1::ReadSession>(
+                   google::cloud::bigquery::storage::v1beta1::
+                       CreateReadSessionRequest const&));
+
+  MOCK_METHOD1(
+      ReadRows,
+      std::unique_ptr<bigquery::internal::StreamReader<
+          google::cloud::bigquery::storage::v1beta1::ReadRowsResponse>>(
+          google::cloud::bigquery::storage::v1beta1::ReadRowsRequest const&));
+};
+
+}  // namespace BIGQUERY_CLIENT_NS
+}  // namespace bigquery_testing
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_BIGQUERY_TESTING_MOCK_BIGQUERY_READ_STUB_H_

--- a/google/cloud/bigquery/version.h
+++ b/google/cloud/bigquery/version.h
@@ -15,11 +15,10 @@
 #ifndef BIGQUERY_VERSION_H_
 #define BIGQUERY_VERSION_H_
 
-#include <sstream>
-#include <string>
-
 #include "google/cloud/bigquery/version_info.h"
 #include "google/cloud/version.h"
+#include <sstream>
+#include <string>
 
 #define BIGQUERY_CLIENT_NS                              \
   GOOGLE_CLOUD_CPP_VEVAL(BIGQUERY_CLIENT_VERSION_MAJOR, \


### PR DESCRIPTION
For now, Read(ReadStream const&) just returns an empty Row object per row encountered. Once we take a dependency on Apache Arrow and the Spanner Row class is implemented, I'll send a separate PR to actually parse the rows. I'll also add more unit tests at that point.

Much of this code is heavily inspired by the Spanner C++ library.

Sample output form samples/read.cc:

```
Starting stream: projects/aryann-bigquery/locations/us/streams/Egh4YURvYmJhbRoCaXIoAQ
  Current offset: 1; fraction consumed: 0
  Current offset: 2; fraction consumed: 0
  Current offset: 3; fraction consumed: 0
  Current offset: 4; fraction consumed: 0
  Current offset: 5; fraction consumed: 0
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-bigquery/19)
<!-- Reviewable:end -->
