### PR TITLE
Add Apache Arrow to the CMake super build

### DIFF
--- a/super/CMakeLists.txt
+++ b/super/CMakeLists.txt
@@ -23,6 +23,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(GOOGLE_CLOUD_CPP_BIGQUERY_ROOT "${PROJECT_SOURCE_DIR}/..")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
 
+include(external/apache-arrow)
 include(external/google-cloud-cpp-common)
 include(external/googletest)
 include(external/external-project-helpers)
@@ -34,7 +35,7 @@ set_external_project_build_parallel_level(PARALLEL)
 include(ExternalProject)
 ExternalProject_Add(
     google-cloud-cpp-bigquery-as-external
-    DEPENDS google-cloud-cpp-common-project googletest-project
+    DEPENDS google-cloud-cpp-common-project googletest-project apache-arrow-project
     EXCLUDE_FROM_ALL OFF
     BUILD_ALWAYS 1
     PREFIX "${CMAKE_BINARY_DIR}/build/google-cloud-cpp-bigquery"

--- a/super/external/apache-arrow.cmake
+++ b/super/external/apache-arrow.cmake
@@ -1,0 +1,49 @@
+# ~~~
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+include(ExternalProject)
+include(external/external-project-helpers)
+
+if (NOT TARGET apache-arrow-project)
+    set(GOOGLE_CLOUD_CPP_APACHE_ARROW_URL
+        "https://www-us.apache.org/dist/arrow/arrow-0.15.0/apache-arrow-0.15.0.tar.gz"
+    )
+    set(GOOGLE_CLOUD_CPP_APACHE_ARROW_SHA256
+        "d1072d8c4bf9166949f4b722a89350a88b7c8912f51642a5d52283448acdfd58")
+
+    google_cloud_cpp_set_prefix_vars()
+
+    set_external_project_build_parallel_level(PARALLEL)
+
+    ExternalProject_Add(
+        apache-arrow-project
+        EXCLUDE_FROM_ALL ON
+        PREFIX "${CMAKE_BINARY_DIR}/external/apache-arrow"
+        INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
+        URL ${GOOGLE_CLOUD_CPP_APACHE_ARROW_URL}
+        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_APACHE_ARROW_SHA256}
+        LIST_SEPARATOR |
+        SOURCE_SUBDIR cpp
+        CMAKE_ARGS -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+                   -DCMAKE_INSTALL_PATH=${GOOGLE_CLOUD_CPP_INSTALL_PATH}
+                   -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+                   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> ${PARALLEL}
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON)
+endif ()


### PR DESCRIPTION
I probably won't start using this until we also have a corresponding Bazel dependency.

@emkornfield is working on a Bazel rule for a limited set of the C++ faculties of Apache Arrow. Assuming we can successfully sell Bazel to the Apache Arrow community, we will use the new target. :)

Otherwise, we'll have to figure out another way to integrate Arrow into Bazel.

@emkornfield, please let me know if you have any thoughts on the type of build I'm doing. It looks like the default build without any options in cpp/ is a minimal build, which is what we want.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-bigquery/30)
<!-- Reviewable:end -->
