### PR TITLE
cleanup: Enable flag enable_opentelemetry in bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -55,9 +55,7 @@ common:macos --repo_env=BAZEL_NO_APPLE_CPP_TOOLCHAIN=1
 test --test_env=GTEST_SHUFFLE --test_env=GTEST_RANDOM_SEED
 
 # By default, build the library with OpenTelemetry
-# Enable the config when the bool flag is visible.
-# https://github.com/googleapis/google-cloud-cpp-bigquery/issues/98
-# build --@com_google_googleapis_google_cloud_cpp//:enable_opentelemetry
+build --@com_google_googleapis_google_cloud_cpp//:enable_opentelemetry
 
 # Don't show warnings when building external dependencies. This still shows
 # warnings when using these dependencies (say in headers).

--- a/google/cloud/bigquery_unified/BUILD.bazel
+++ b/google/cloud/bigquery_unified/BUILD.bazel
@@ -24,7 +24,7 @@ licenses(["notice"])  # Apache 2.0
 config_setting(
     name = "enable_opentelemetry",
     flag_values = {
-        "@google_cloud_cpp//:enable_opentelemetry": "true",
+        "@com_google_googleapis_google_cloud_cpp//:enable_opentelemetry": "true",
     },
 )
 
@@ -60,15 +60,13 @@ cc_library(
     name = "google_cloud_cpp_bigquery_bigquery_unified",
     srcs = google_cloud_cpp_bigquery_bigquery_unified_srcs,
     hdrs = google_cloud_cpp_bigquery_bigquery_unified_hdrs,
-    # Enable the config when the bool flag is visible.
-    # https://github.com/googleapis/google-cloud-cpp-bigquery/issues/98
-    # defines = select({
-    #     ":enable_opentelemetry": [
-    #         # Enable OpenTelemetry features in google-cloud-cpp
-    #         "GOOGLE_CLOUD_CPP_BIGQUERY_HAVE_OPENTELEMETRY",
-    #     ],
-    #     "//conditions:default": [],
-    # }),
+    defines = select({
+        ":enable_opentelemetry": [
+            # Enable OpenTelemetry features in google-cloud-cpp
+            "GOOGLE_CLOUD_CPP_BIGQUERY_HAVE_OPENTELEMETRY",
+        ],
+        "//conditions:default": [],
+    }),
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_bigquery_common",

--- a/google/cloud/bigquery_unified/connection_test.cc
+++ b/google/cloud/bigquery_unified/connection_test.cc
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 #include "google/cloud/bigquery_unified/connection.h"
+#include "google/cloud/bigquery_unified/job_options.h"
 #include "google/cloud/bigquery_unified/testing_util/opentelemetry_matchers.h"
 #include "google/cloud/bigquery_unified/version.h"
+#include "google/cloud/common_options.h"
 
 namespace google::cloud::bigquery_unified {
 GOOGLE_CLOUD_CPP_BIGQUERY_INLINE_NAMESPACE_BEGIN
@@ -30,7 +32,12 @@ using ::testing::Not;
 TEST(BigQueryUnifiedConnectionTest, TracingEnabled) {
   auto span_catcher = testing_util::InstallSpanCatcher();
 
-  auto options = EnableTracing(Options{});
+  auto options = EnableTracing(
+      Options{}
+          .set<EndpointOption>("localhost:1")
+          .set<bigquery_unified::RetryPolicyOption>(
+              std::make_shared<bigquery_unified::LimitedErrorCountRetryPolicy>(
+                  0)));
   auto conn = MakeConnection(std::move(options));
   google::cloud::internal::OptionsSpan span(
       google::cloud::internal::MergeOptions(Options{}, conn->options()));
@@ -46,7 +53,12 @@ TEST(BigQueryUnifiedConnectionTest, TracingEnabled) {
 TEST(BigQueryUnifiedConnectionTest, TracingDisabled) {
   auto span_catcher = testing_util::InstallSpanCatcher();
 
-  auto options = DisableTracing(Options{});
+  auto options = DisableTracing(
+      Options{}
+          .set<EndpointOption>("localhost:1")
+          .set<bigquery_unified::RetryPolicyOption>(
+              std::make_shared<bigquery_unified::LimitedErrorCountRetryPolicy>(
+                  0)));
   auto conn = MakeConnection(std::move(options));
   google::cloud::internal::OptionsSpan span(
       google::cloud::internal::MergeOptions(Options{}, conn->options()));

--- a/google/cloud/bigquery_unified/testing_util/BUILD.bazel
+++ b/google/cloud/bigquery_unified/testing_util/BUILD.bazel
@@ -20,6 +20,13 @@ package(default_visibility = ["//:__subpackages__"])
 
 licenses(["notice"])  # Apache 2.0
 
+config_setting(
+    name = "enable_opentelemetry",
+    flag_values = {
+        "@com_google_googleapis_google_cloud_cpp//:enable_opentelemetry": "true",
+    },
+)
+
 cc_library(
     name = "google_cloud_cpp_bigquery_bigquery_unified_testing_private",
     testonly = True,
@@ -34,6 +41,12 @@ cc_library(
             "GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE",
         ],
         "//conditions:default": [],
+    }) + select({
+        ":enable_opentelemetry": [
+            # Enable OpenTelemetry features in google-cloud-cpp
+            "GOOGLE_CLOUD_CPP_BIGQUERY_HAVE_OPENTELEMETRY",
+        ],
+        "//conditions:default": [],
     }),
     deps = [
         "//:common",
@@ -41,14 +54,11 @@ cc_library(
         "@com_google_absl//absl/debugging:symbolize",
         "@com_google_googletest//:gtest_main",
         "@google_cloud_cpp//:common",
-    ],
-    # Enable the config when the bool flag is visible.
-    # https://github.com/googleapis/google-cloud-cpp-bigquery/issues/98
-    # + select({
-    #     ":enable_opentelemetry": [
-    #         "@io_opentelemetry_cpp//exporters/memory:in_memory_span_exporter",
-    #         "@io_opentelemetry_cpp//sdk/src/trace",
-    #     ],
-    #     "//conditions:default": [],
-    # })
+    ] + select({
+        ":enable_opentelemetry": [
+            "@io_opentelemetry_cpp//exporters/memory:in_memory_span_exporter",
+            "@io_opentelemetry_cpp//sdk/src/trace",
+        ],
+        "//conditions:default": [],
+    }),
 )


### PR DESCRIPTION
#98 

1. Enable flag enable_opentelemetry in bazel.
2. Make query in connection_test.cc fail sooner.