### PR TITLE
chore: replace old cpp teams with cloud-sdk-cpp-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # is the same as .gitignore.
 
 # The owners for all files in the repo.
-* @googleapis/cloud-cxx-owners
+* @googleapis/cloud-sdk-cpp-team


### PR DESCRIPTION
Replace googleapis/cloud-cxx-owners with googleapis/cloud-sdk-cpp-team.

b/479547456